### PR TITLE
Copyright workflow - google/addlicense

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -1,0 +1,28 @@
+# Workflow that is used in other repos to check the copyright headers
+name: Check copyright headers
+
+on:
+  workflow_call:
+    inputs:
+      args:
+        description: 'Arguments to be passed to the google/addlicense CLI. Generally this can be configured with additional -ignore flags to exclude more file extensions'
+        type: string
+
+jobs:
+  copyright:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Validate Header Compliance
+        run: |
+          set -e
+          curl -sSfL https://github.com/google/addlicense/releases/download/v1.2.0/addlicense_v1.2.0_Linux_x86_64.tar.gz | tar -xzf - -C /usr/local/bin addlicense
+          
+          if ! addlicense -check -ignore "**/*.tf" -ignore "**/*.hcl" -ignore "**/*.yml" -ignore "**/*.sh" -ignore "**/*.ps1" -ignore "**/*.toml" -ignore ".git/**" ${{ inputs.args }} . ; then
+            echo >&2 "ERROR: some files are missing required copyright headers"
+            exit 1
+          fi
+          exit 0
+        shell: bash


### PR DESCRIPTION
This PR adds the copyright workflow based on [google/addlicense](https://github.com/google/addlicense).

This is meant to be used as a template and configured in each repo `.github/workflows` directory that needs to ensure that all files have the copyright headers configured properly.

The workflow has one input argument where additional `-ignore` flags can be configured. Whatever is configured in there will be appended to the already well known patterns that need to be ignored.

The google/addlicense simply checks the existence of the headers and do not check the content of those which means that the `-f` flag (the license file) is not provided. The flag needs to be used only when `addlicense` is used to add the headers.