### PR TITLE
Copyright workflow - B1NARY-GR0UP/nwa

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -1,0 +1,28 @@
+# Workflow that is used in other repos to check the copyright headers
+name: Check copyright headers
+
+on:
+  workflow_call:
+    inputs:
+      args:
+        description: 'Arguments to be passed to the google/addlicense CLI. Generally this can be configured with additional -ignore flags to exclude more file extensions'
+        type: string
+
+jobs:
+  copyright:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Validate Header Compliance
+        run: |
+          set -e
+          curl -sSfL https://github.com/google/addlicense/releases/download/v1.2.0/addlicense_v1.2.0_Linux_x86_64.tar.gz | tar -xzf - -C /usr/local/bin addlicense
+          
+          if ! addlicense -check -ignore "**/*.tf" -ignore "**/*.hcl" -ignore "**/*.yml" -ignore "**/*.sh" -ignore "**/*.ps1" -ignore "**/*.toml" -ignore ".git/**" ${{ inputs.args }} . ; then
+            echo >&2 "ERROR: some files are missing required copyright headers"
+            exit 1
+          fi
+          exit 0
+        shell: bash

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -4,8 +4,17 @@ name: Check copyright headers
 on:
   workflow_call:
     inputs:
-      args:
-        description: 'Arguments to be passed to the google/addlicense CLI. Generally this can be configured with additional -ignore flags to exclude more file extensions'
+      header-to-check:
+        description: 'Contains the template of the header to be checked for'
+        default: "Copyright (c) The OpenTofu Authors\nSPDX-License-Identifier: MPL-2.0\nCopyright (c) 2023 HashiCorp, Inc.\nSPDX-License-Identifier: MPL-2.0"
+        type: string
+      search-patterns:
+        description: 'The pattern to be used when scaning for files to be checked'
+        default: '"**/*.go" "**/*.proto"'
+        type: string
+      ignore-flags:
+        description: 'A list of -s (--skip) flags to be used when specific paths should be excluded'
+        default: '-s ".git/**/*"'
         type: string
 
 jobs:
@@ -18,9 +27,11 @@ jobs:
       - name: Validate Header Compliance
         run: |
           set -e
-          curl -sSfL https://github.com/google/addlicense/releases/download/v1.2.0/addlicense_v1.2.0_Linux_x86_64.tar.gz | tar -xzf - -C /usr/local/bin addlicense
+          curl -sSfL https://github.com/B1NARY-GR0UP/nwa/releases/download/v0.8.0/nwa_Linux_x86_64.tar.gz | tar -xzf - -C /usr/local/bin nwa
           
-          if ! addlicense -check -ignore "**/*.tf" -ignore "**/*.hcl" -ignore "**/*.yml" -ignore "**/*.sh" -ignore "**/*.ps1" -ignore "**/*.toml" -ignore ".git/**" ${{ inputs.args }} . ; then
+          _copyright_header_templ_file="copyright_header_template"
+          echo "${{ inputs.header-to-check }}" > "${_copyright_header_templ_file}" 
+          if ! nwa check -f -T static --tmpl "${_copyright_header_templ_file}" ${{ inputs.ignore-flags }} ${{ inputs.search-patterns }} ; then
             echo >&2 "ERROR: some files are missing required copyright headers"
             exit 1
           fi


### PR DESCRIPTION
This is a workflow template to check copyright headers that uses [B1NARY-GR0UP/nwa](https://github.com/B1NARY-GR0UP/nwa).

The workflow has several inputs with sane defaults:
* `header-to-check` - the header that is required to be on each scanned file
* `search-patterns` - [doublestar](https://github.com/bmatcuk/doublestar) patterns to include files to scan
* `ignore-flags` - `-s`/`--skip` flags to paths that the repo does not need to check

