### PR TITLE
Copyright workflow - bash

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -1,0 +1,96 @@
+# Workflow that is used in other repos to check the copyright headers
+name: Check copyright headers
+
+on:
+  workflow_call:
+    inputs:
+      header-to-check:
+        description: 'Contains the template of the header to be checked for'
+        default: "Copyright (c) The OpenTofu Authors\nSPDX-License-Identifier: MPL-2.0\nCopyright (c) 2023 HashiCorp, Inc.\nSPDX-License-Identifier: MPL-2.0\n"
+        type: string
+      search-patterns:
+        description: 'A list of patterns to search separated by spaces'
+        default: '"*.go" "*.proto"'
+        type: string
+      ignore-patterns:
+        description: 'A list of patterns to ignore separated by spaces'
+        default: '"*/.git*" "*/vendor/*" "*/node_modules/*"'
+        type: string
+jobs:
+  copyright:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Validate Header Compliance
+        run: |
+          is_generated() {
+            if grep -q -E '(^.{1,2} Code generated .* DO NOT EDIT\.\r?$)' "$1"; then
+              return 0
+            fi
+            return 1
+          }
+          # Removes the year from the expected header and inlines everything  
+          cleanup_header() {
+            echo "$1" | sed -E 's/[0-9]{4}-[0-9]{4}//g;s/[0-9]{4}//g;' | tr '\n' ' '
+          }
+          
+          # Process the header to check against and print it
+          header_to_use=$(printf "${{ inputs.header-to-check }}\n")
+          header_lines=$(echo "${header_to_use}" | wc -l)
+          clean_header="$(cleanup_header "${header_to_use}")"
+          printf "Copyright checker %s\n\n" "${clean_header}"
+          
+          include_patterns=(${{ inputs.search-patterns }})
+          ignore_paths=(${{ inputs.ignore-patterns }})
+          
+          find_args=(".")
+          if [ ${#ignore_paths[@]} -gt 0 ]; then
+            find_args+=("(")
+            for i in "${!ignore_paths[@]}"; do
+              if [ "$i" -gt 0 ]; then find_args+=("-o"); fi
+              find_args+=("-path" "${ignore_paths[$i]}")
+            done
+            find_args+=(")" "-prune" "-o")
+          fi
+          
+          find_args+=("(")
+          for i in "${!include_patterns[@]}"; do
+            if [ "$i" -gt 0 ]; then find_args+=("-o"); fi
+            find_args+=("-name" "${include_patterns[$i]}")
+          done
+          find_args+=(")" "-print")
+          
+          echo "Find command ready: find ${find_args[@]}"
+          echo "Scanning files for copyright headers..."
+          
+          mismatched_count=0
+          scanned_count=0
+          while IFS= read -r file; do
+            ((scanned_count++))
+          
+            if is_generated "${file}"; then
+            echo "Skipping: '${file}' is a generated file."
+              continue
+            fi
+            
+            # Read the first N lines of the source file depending on the template length.
+            # Also, cleanup the comment syntax from the headers and inline everything
+            file_header="$(head -n "${header_lines}" "${file}" | sed -e 's#^//##' -e 's/^#//' -e 's/^\s*//' || true)"
+            clean_file_header="$(cleanup_header "${file_header}")"
+          
+            if ! echo "${clean_file_header}" | grep -q "^${clean_header}$"; then
+              printf "ERROR: %s missing or not matching the expected header.\n\tWanted:\n\t\t%s\n\tGot:\n\t\t%s\n" "${file}" "${clean_header}" "${clean_file_header}"
+              ((mismatched_count++))
+            fi
+          done < <(find "${find_args[@]}")
+          
+          printf "\nScan Summary: scanned=%d, mismatched=%d\n" ${scanned_count} ${mismatched_count}
+            
+          if [ "${mismatched_count}" -gt 0 ]; then
+            echo >&2 "ERROR: some files are missing required copyright headers"
+            exit 1
+          fi
+          exit 0
+        shell: bash {0}

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -6,8 +6,8 @@ on:
     inputs:
       header-to-check:
         description: 'Contains the template of the header to be checked for'
-        default: "Copyright (c) The OpenTofu Authors\nSPDX-License-Identifier: MPL-2.0\nCopyright (c) 2023 HashiCorp, Inc.\nSPDX-License-Identifier: MPL-2.0\n"
         type: string
+        required: false
       search-patterns:
         description: 'A list of patterns to search separated by spaces'
         default: "*.go *.proto"

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -10,11 +10,11 @@ on:
         type: string
       search-patterns:
         description: 'A list of patterns to search separated by spaces'
-        default: '"*.go" "*.proto"'
+        default: "*.go *.proto"
         type: string
       ignore-patterns:
         description: 'A list of patterns to ignore separated by spaces'
-        default: '"*/.git*" "*/vendor/*" "*/node_modules/*"'
+        default: "*/.git* */vendor/* */node_modules/*"
         type: string
 jobs:
   copyright:
@@ -23,74 +23,20 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          path: './target'
+      - name: Checkout Repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: '1'
+          repository: 'opentofu/scripts'
+          ref: 'copyright-workflow-bash'
+          path: './scripts'
       - name: Validate Header Compliance
         run: |
-          is_generated() {
-            if grep -q -E '(^.{1,2} Code generated .* DO NOT EDIT\.\r?$)' "$1"; then
-              return 0
-            fi
-            return 1
-          }
-          # Removes the year from the expected header and inlines everything  
-          cleanup_header() {
-            echo "$1" | sed -E 's/[0-9]{4}-[0-9]{4}//g;s/[0-9]{4}//g;' | tr '\n' ' '
-          }
-          
-          # Process the header to check against and print it
-          header_to_use=$(printf "${{ inputs.header-to-check }}\n")
-          header_lines=$(echo "${header_to_use}" | wc -l)
-          clean_header="$(cleanup_header "${header_to_use}")"
-          printf "Copyright checker %s\n\n" "${clean_header}"
-          
-          include_patterns=(${{ inputs.search-patterns }})
-          ignore_paths=(${{ inputs.ignore-patterns }})
-          
-          find_args=(".")
-          if [ ${#ignore_paths[@]} -gt 0 ]; then
-            find_args+=("(")
-            for i in "${!ignore_paths[@]}"; do
-              if [ "$i" -gt 0 ]; then find_args+=("-o"); fi
-              find_args+=("-path" "${ignore_paths[$i]}")
-            done
-            find_args+=(")" "-prune" "-o")
-          fi
-          
-          find_args+=("(")
-          for i in "${!include_patterns[@]}"; do
-            if [ "$i" -gt 0 ]; then find_args+=("-o"); fi
-            find_args+=("-name" "${include_patterns[$i]}")
-          done
-          find_args+=(")" "-print")
-          
-          echo "Find command ready: find ${find_args[@]}"
-          echo "Scanning files for copyright headers..."
-          
-          mismatched_count=0
-          scanned_count=0
-          while IFS= read -r file; do
-            ((scanned_count++))
-          
-            if is_generated "${file}"; then
-            echo "Skipping: '${file}' is a generated file."
-              continue
-            fi
-            
-            # Read the first N lines of the source file depending on the template length.
-            # Also, cleanup the comment syntax from the headers and inline everything
-            file_header="$(head -n "${header_lines}" "${file}" | sed -e 's#^//##' -e 's/^#//' -e 's/^\s*//' || true)"
-            clean_file_header="$(cleanup_header "${file_header}")"
-          
-            if ! echo "${clean_file_header}" | grep -q "^${clean_header}$"; then
-              printf "ERROR: %s missing or not matching the expected header.\n\tWanted:\n\t\t%s\n\tGot:\n\t\t%s\n" "${file}" "${clean_header}" "${clean_file_header}"
-              ((mismatched_count++))
-            fi
-          done < <(find "${find_args[@]}")
-          
-          printf "\nScan Summary: scanned=%d, mismatched=%d\n" ${scanned_count} ${mismatched_count}
-            
-          if [ "${mismatched_count}" -gt 0 ]; then
-            echo >&2 "ERROR: some files are missing required copyright headers"
+          chmod +x ./scripts/sh/copyright_check.sh 
+          cd ./target
+          if ! ../scripts/sh/copyright_check.sh "${{ inputs.header-to-check }}" "${{ inputs.search-patterns }}" "${{ inputs.ignore-patterns }}"; then
+            echo >&2 "ERROR: some files are missing required copyright headers. To check this locally, run 'curl -fsSL https://raw.githubusercontent.com/opentofu/scripts/copyright-workflow-bash/sh/copyright_check.sh | bash -s -- \"${{ inputs.header-to-check }}\" \"${{ inputs.search-patterns }}\" \"${{ inputs.ignore-patterns }}\"'"
             exit 1
           fi
-          exit 0
-        shell: bash {0}

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: '1'
           repository: 'opentofu/scripts'
-          ref: 'copyright-workflow-bash'
+          ref: 'main'
           path: './scripts'
       - name: Validate Header Compliance
         run: |

--- a/sh/copyright_check.sh
+++ b/sh/copyright_check.sh
@@ -25,8 +25,16 @@ cleanup_header() {
   echo "$1" | sed -E 's/[0-9]{4}-[0-9]{4}//g;s/[0-9]{4}//g;' | tr '\n' ' '
 }
 
+header="Copyright (c) The OpenTofu Authors
+SPDX-License-Identifier: MPL-2.0
+Copyright (c) 2023 HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+"
+if [ -n "${1}" ]; then
+  header="${1}"
+fi
 # Process the header to check against and print it
-header_to_use=$(printf "%s" "${1}")
+header_to_use=$(printf "%s" "${header}")
 header_lines=$(echo "${header_to_use}" | wc -l)
 clean_header="$(cleanup_header "${header_to_use}")"
 printf "Header to check:\n---\n%s\n---\n" "${clean_header}"

--- a/sh/copyright_check.sh
+++ b/sh/copyright_check.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# This checks the indicated files for the given copyright header.
+#
+# Some relevant things this script does:
+# * From the given header, it removes any 4 digit number, as it is considered to be the year which can be different
+#   from file to file.
+# * It skips any Golang generated file
+#
+# Requires 3 inputs:
+# * A string containing the header to be checked against. (e.g.: "Copyright (c) The OpenTofu Authors\nSPDX-License-Identifier: MPL-2.0\nCopyright (c) 2023 HashiCorp, Inc.\nSPDX-License-Identifier: MPL-2.0\n")
+# * A string containing space separated patterns for the paths to be included in the scan (e.g.: '"*.go" "*.proto"')
+# * A string containing space separated patterns for files or paths to ignore (e.g.: '"*/.git*" "*/vendor/*" "*/node_modules/*"')
+#
+# Example usage: ./copyright_check.sh "Copyright (c) The OpenTofu Authors\nSPDX-License-Identifier: MPL-2.0\nCopyright (c) 2023 HashiCorp, Inc.\nSPDX-License-Identifier: MPL-2.0\n" '"*.go" "*.proto"' '"*/.git*" "*/vendor/*" "*/node_modules/*"'
+
+
+is_generated() {
+  if grep -q -E '(^.{1,2} Code generated .* DO NOT EDIT\.\r?$)' "$1"; then
+    return 0
+  fi
+  return 1
+}
+# Removes the year from the expected header and inlines everything
+cleanup_header() {
+  echo "$1" | sed -E 's/[0-9]{4}-[0-9]{4}//g;s/[0-9]{4}//g;' | tr '\n' ' '
+}
+
+# Process the header to check against and print it
+header_to_use=$(printf "%s" "${1}")
+header_lines=$(echo "${header_to_use}" | wc -l)
+clean_header="$(cleanup_header "${header_to_use}")"
+printf "Header to check:\n---\n%s\n---\n" "${clean_header}"
+
+# shellcheck disable=SC2206
+include_patterns=(${2})
+# shellcheck disable=SC2206
+ignore_paths=(${3})
+
+find_args=(".")
+if [ ${#ignore_paths[@]} -gt 0 ]; then
+  find_args+=("(")
+  for i in "${!ignore_paths[@]}"; do
+    if [ "$i" -gt 0 ]; then find_args+=("-o"); fi
+    find_args+=("-path" "${ignore_paths[$i]}")
+  done
+  find_args+=(")" "-prune" "-o")
+fi
+
+find_args+=("(")
+for i in "${!include_patterns[@]}"; do
+  if [ "$i" -gt 0 ]; then find_args+=("-o"); fi
+  find_args+=("-name" "${include_patterns[$i]}")
+done
+find_args+=(")" "-print")
+
+echo "Find command ready: find ${find_args[*]}"
+echo "Scanning files for copyright headers..."
+
+mismatched_count=0
+scanned_count=0
+while IFS= read -r file; do
+  ((scanned_count++))
+
+  if is_generated "${file}"; then
+  echo "Skipping: '${file}' is a generated file."
+    continue
+  fi
+
+  # Read the first N lines of the source file depending on the template length.
+  # Also, cleanup the comment syntax from the headers and inline everything
+  file_header="$(head -n "${header_lines}" "${file}" | sed -e 's#^//##' -e 's/^#//' -e 's/^\s*//' || true)"
+  clean_file_header="$(cleanup_header "${file_header}")"
+
+  if ! echo "${clean_file_header}" | grep -q "^${clean_header}$"; then
+    printf "ERROR: %s missing or not matching the expected header.\n\tWanted:\n\t\t%s\n\tGot:\n\t\t%s\n" "${file}" "${clean_header}" "${clean_file_header}"
+    ((mismatched_count++))
+  fi
+done < <(find "${find_args[@]}")
+
+printf "\nScan Summary: scanned=%d, mismatched=%d\n" ${scanned_count} ${mismatched_count}
+
+if [ "${mismatched_count}" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/sh/copyright_check.sh
+++ b/sh/copyright_check.sh
@@ -11,7 +11,7 @@
 # * A string containing space separated patterns for the paths to be included in the scan (e.g.: '"*.go" "*.proto"')
 # * A string containing space separated patterns for files or paths to ignore (e.g.: '"*/.git*" "*/vendor/*" "*/node_modules/*"')
 #
-# Example usage: ./copyright_check.sh "Copyright (c) The OpenTofu Authors\nSPDX-License-Identifier: MPL-2.0\nCopyright (c) 2023 HashiCorp, Inc.\nSPDX-License-Identifier: MPL-2.0\n" '"*.go" "*.proto"' '"*/.git*" "*/vendor/*" "*/node_modules/*"'
+# Example usage: ./copyright_check.sh "Copyright (c) The OpenTofu Authors\nSPDX-License-Identifier: MPL-2.0\nCopyright (c) 2023 HashiCorp, Inc.\nSPDX-License-Identifier: MPL-2.0\n" "*.go *.proto" "*/.git* */vendor/* */node_modules/*"
 
 
 is_generated() {

--- a/sh/copyright_check.sh
+++ b/sh/copyright_check.sh
@@ -20,9 +20,9 @@ is_generated() {
   fi
   return 1
 }
-# Removes the year from the expected header and inlines everything
+# Removes the year from the expected header and inlines everything. Additionally, replaces any double space with a single one
 cleanup_header() {
-  echo "$1" | sed -E 's/[0-9]{4}-[0-9]{4}//g;s/[0-9]{4}//g;' | tr '\n' ' '
+  echo "$1" | sed -E 's/[0-9]{4}-[0-9]{4}//g;s/[0-9]{4}//g;' | tr '\n' ' ' | sed 's/  / /g'
 }
 
 header="Copyright (c) The OpenTofu Authors

--- a/sh/readme.md
+++ b/sh/readme.md
@@ -26,3 +26,7 @@ This is really useful when wanting to propagate (or refresh) the workflows manag
 ### [`disable_unwanted_workflows.sh`](./disable_unwanted_workflows.sh)
 This gets a file with repositories and disables all of their workflows that are not in the above mentioned workflows directory.
 This is meant to be used to disable any workflow that is inherited from the forked repo that is not necessary in the OpenTofu world.
+
+### [`copyright_check.sh`](./copyright_check.sh)
+This checks the indicated files for the given copyright header. This is used in the whole organisation to check
+for the required copyright headers.


### PR DESCRIPTION
This is a workflow template to check copyright headers that uses a custom written bash script.

The workflow has several inputs with sane defaults:
* `header-to-check` - the header that is required to be on each scanned file
* `search-patterns` - [doublestar](https://github.com/bmatcuk/doublestar) patterns to include files to scan
* `ignore-patterns` - A list of patterns to ignore separated by spaces

